### PR TITLE
feat: Credential Registration PoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # liquid-auth-ios
 Liquid Auth Swift client.
+
+Currently work in progress.

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		6EE5379A2DAE75340032EC12 /* SwiftCBOR in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537992DAE75340032EC12 /* SwiftCBOR */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		6E68E69D2DA924940087CB6D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -52,6 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6EE5379A2DAE75340032EC12 /* SwiftCBOR in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +83,7 @@
 				6E68E68E2DA924920087CB6D /* liquid-auth-ios */,
 				6E68E69F2DA924940087CB6D /* liquid-auth-iosTests */,
 				6E68E6A92DA924940087CB6D /* liquid-auth-iosUITests */,
+				6EE537982DAE75340032EC12 /* Frameworks */,
 				6E68E68D2DA924920087CB6D /* Products */,
 			);
 			sourceTree = "<group>";
@@ -90,6 +96,13 @@
 				6E68E6A62DA924940087CB6D /* liquid-auth-iosUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		6EE537982DAE75340032EC12 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -112,6 +125,7 @@
 			);
 			name = "liquid-auth-ios";
 			packageProductDependencies = (
+				6EE537992DAE75340032EC12 /* SwiftCBOR */,
 			);
 			productName = "liquid-auth-ios";
 			productReference = 6E68E68C2DA924920087CB6D /* liquid-auth-ios.app */;
@@ -195,6 +209,9 @@
 			);
 			mainGroup = 6E68E6832DA924920087CB6D;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6E68E68D2DA924920087CB6D /* Products */;
 			projectDirPath = "";
@@ -556,6 +573,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/valpackett/SwiftCBOR";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		6EE537992DAE75340032EC12 /* SwiftCBOR */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */;
+			productName = SwiftCBOR;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 6E68E6842DA924920087CB6D /* Project object */;
 }

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		6EE537DE2DAFC2540032EC12 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537DD2DAFC2540032EC12 /* Starscream */; };
 		6EE537E62DBD5E6A0032EC12 /* deterministicP256-swift in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537E52DBD5E6A0032EC12 /* deterministicP256-swift */; };
 		6EE537E92DBD631D0032EC12 /* MnemonicSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537E82DBD631D0032EC12 /* MnemonicSwift */; };
-		6EE537EB2DBD636F0032EC12 /* x-hd-wallet-api in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537EA2DBD636F0032EC12 /* x-hd-wallet-api */; };
 		6EE537F32DBD64D80032EC12 /* Base32 in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537F22DBD64D80032EC12 /* Base32 */; };
 /* End PBXBuildFile section */
 
@@ -64,7 +63,6 @@
 			files = (
 				6EE537F32DBD64D80032EC12 /* Base32 in Frameworks */,
 				6EE5379A2DAE75340032EC12 /* SwiftCBOR in Frameworks */,
-				6EE537EB2DBD636F0032EC12 /* x-hd-wallet-api in Frameworks */,
 				6EE537D92DAFA7AE0032EC12 /* WebRTC in Frameworks */,
 				6EE537E62DBD5E6A0032EC12 /* deterministicP256-swift in Frameworks */,
 				6EE537E92DBD631D0032EC12 /* MnemonicSwift in Frameworks */,
@@ -142,7 +140,6 @@
 				6EE537DD2DAFC2540032EC12 /* Starscream */,
 				6EE537E52DBD5E6A0032EC12 /* deterministicP256-swift */,
 				6EE537E82DBD631D0032EC12 /* MnemonicSwift */,
-				6EE537EA2DBD636F0032EC12 /* x-hd-wallet-api */,
 				6EE537F22DBD64D80032EC12 /* Base32 */,
 			);
 			productName = "liquid-auth-ios";
@@ -231,10 +228,10 @@
 				6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */,
 				6EE537D72DAFA7540032EC12 /* XCRemoteSwiftPackageReference "WebRTC" */,
 				6EE537DC2DAFC2540032EC12 /* XCRemoteSwiftPackageReference "Starscream" */,
-				6EE537E32DBD5E360032EC12 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */,
 				6EE537E42DBD5E6A0032EC12 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */,
 				6EE537E72DBD631D0032EC12 /* XCRemoteSwiftPackageReference "MnemonicSwift" */,
 				6EE537F12DBD64D80032EC12 /* XCRemoteSwiftPackageReference "Base32" */,
+				6ECF13E52DBEBA73006E0BE0 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6E68E68D2DA924920087CB6D /* Products */;
@@ -599,6 +596,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		6ECF13E52DBEBA73006E0BE0 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/algorandfoundation/xHD-Wallet-API-swift/";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/valpackett/SwiftCBOR";
@@ -621,14 +626,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 4.0.8;
-			};
-		};
-		6EE537E32DBD5E360032EC12 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/algorandfoundation/xHD-Wallet-API-swift";
-			requirement = {
-				branch = main;
-				kind = branch;
 			};
 		};
 		6EE537E42DBD5E6A0032EC12 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */ = {
@@ -682,11 +679,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6EE537E72DBD631D0032EC12 /* XCRemoteSwiftPackageReference "MnemonicSwift" */;
 			productName = MnemonicSwift;
-		};
-		6EE537EA2DBD636F0032EC12 /* x-hd-wallet-api */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6EE537E32DBD5E360032EC12 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */;
-			productName = "x-hd-wallet-api";
 		};
 		6EE537F22DBD64D80032EC12 /* Base32 */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		6EE5379A2DAE75340032EC12 /* SwiftCBOR in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537992DAE75340032EC12 /* SwiftCBOR */; };
+		6EE537D92DAFA7AE0032EC12 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537D82DAFA7AE0032EC12 /* WebRTC */; };
+		6EE537DE2DAFC2540032EC12 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537DD2DAFC2540032EC12 /* Starscream */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +59,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				6EE5379A2DAE75340032EC12 /* SwiftCBOR in Frameworks */,
+				6EE537D92DAFA7AE0032EC12 /* WebRTC in Frameworks */,
+				6EE537DE2DAFC2540032EC12 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -126,6 +130,8 @@
 			name = "liquid-auth-ios";
 			packageProductDependencies = (
 				6EE537992DAE75340032EC12 /* SwiftCBOR */,
+				6EE537D82DAFA7AE0032EC12 /* WebRTC */,
+				6EE537DD2DAFC2540032EC12 /* Starscream */,
 			);
 			productName = "liquid-auth-ios";
 			productReference = 6E68E68C2DA924920087CB6D /* liquid-auth-ios.app */;
@@ -211,6 +217,8 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */,
+				6EE537D72DAFA7540032EC12 /* XCRemoteSwiftPackageReference "WebRTC" */,
+				6EE537DC2DAFC2540032EC12 /* XCRemoteSwiftPackageReference "Starscream" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6E68E68D2DA924920087CB6D /* Products */;
@@ -583,6 +591,22 @@
 				kind = branch;
 			};
 		};
+		6EE537D72DAFA7540032EC12 /* XCRemoteSwiftPackageReference "WebRTC" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/stasel/WebRTC";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 135.0.0;
+			};
+		};
+		6EE537DC2DAFC2540032EC12 /* XCRemoteSwiftPackageReference "Starscream" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/daltoniam/Starscream";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.8;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -590,6 +614,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */;
 			productName = SwiftCBOR;
+		};
+		6EE537D82DAFA7AE0032EC12 /* WebRTC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6EE537D72DAFA7540032EC12 /* XCRemoteSwiftPackageReference "WebRTC" */;
+			productName = WebRTC;
+		};
+		6EE537DD2DAFC2540032EC12 /* Starscream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6EE537DC2DAFC2540032EC12 /* XCRemoteSwiftPackageReference "Starscream" */;
+			productName = Starscream;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		6EE5379A2DAE75340032EC12 /* SwiftCBOR in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537992DAE75340032EC12 /* SwiftCBOR */; };
 		6EE537D92DAFA7AE0032EC12 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537D82DAFA7AE0032EC12 /* WebRTC */; };
 		6EE537DE2DAFC2540032EC12 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537DD2DAFC2540032EC12 /* Starscream */; };
+		6EE537E62DBD5E6A0032EC12 /* deterministicP256-swift in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537E52DBD5E6A0032EC12 /* deterministicP256-swift */; };
+		6EE537E92DBD631D0032EC12 /* MnemonicSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537E82DBD631D0032EC12 /* MnemonicSwift */; };
+		6EE537EB2DBD636F0032EC12 /* x-hd-wallet-api in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537EA2DBD636F0032EC12 /* x-hd-wallet-api */; };
+		6EE537F32DBD64D80032EC12 /* Base32 in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537F22DBD64D80032EC12 /* Base32 */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,8 +62,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6EE537F32DBD64D80032EC12 /* Base32 in Frameworks */,
 				6EE5379A2DAE75340032EC12 /* SwiftCBOR in Frameworks */,
+				6EE537EB2DBD636F0032EC12 /* x-hd-wallet-api in Frameworks */,
 				6EE537D92DAFA7AE0032EC12 /* WebRTC in Frameworks */,
+				6EE537E62DBD5E6A0032EC12 /* deterministicP256-swift in Frameworks */,
+				6EE537E92DBD631D0032EC12 /* MnemonicSwift in Frameworks */,
 				6EE537DE2DAFC2540032EC12 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -132,6 +140,10 @@
 				6EE537992DAE75340032EC12 /* SwiftCBOR */,
 				6EE537D82DAFA7AE0032EC12 /* WebRTC */,
 				6EE537DD2DAFC2540032EC12 /* Starscream */,
+				6EE537E52DBD5E6A0032EC12 /* deterministicP256-swift */,
+				6EE537E82DBD631D0032EC12 /* MnemonicSwift */,
+				6EE537EA2DBD636F0032EC12 /* x-hd-wallet-api */,
+				6EE537F22DBD64D80032EC12 /* Base32 */,
 			);
 			productName = "liquid-auth-ios";
 			productReference = 6E68E68C2DA924920087CB6D /* liquid-auth-ios.app */;
@@ -219,6 +231,10 @@
 				6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */,
 				6EE537D72DAFA7540032EC12 /* XCRemoteSwiftPackageReference "WebRTC" */,
 				6EE537DC2DAFC2540032EC12 /* XCRemoteSwiftPackageReference "Starscream" */,
+				6EE537E32DBD5E360032EC12 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */,
+				6EE537E42DBD5E6A0032EC12 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */,
+				6EE537E72DBD631D0032EC12 /* XCRemoteSwiftPackageReference "MnemonicSwift" */,
+				6EE537F12DBD64D80032EC12 /* XCRemoteSwiftPackageReference "Base32" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6E68E68D2DA924920087CB6D /* Products */;
@@ -607,6 +623,38 @@
 				minimumVersion = 4.0.8;
 			};
 		};
+		6EE537E32DBD5E360032EC12 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/algorandfoundation/xHD-Wallet-API-swift";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+		6EE537E42DBD5E6A0032EC12 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/algorandfoundation/deterministic-P256-swift";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+		6EE537E72DBD631D0032EC12 /* XCRemoteSwiftPackageReference "MnemonicSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Electric-Coin-Company/MnemonicSwift/";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.5;
+			};
+		};
+		6EE537F12DBD64D80032EC12 /* XCRemoteSwiftPackageReference "Base32" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/norio-nomura/Base32";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -624,6 +672,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6EE537DC2DAFC2540032EC12 /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
+		};
+		6EE537E52DBD5E6A0032EC12 /* deterministicP256-swift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6EE537E42DBD5E6A0032EC12 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */;
+			productName = "deterministicP256-swift";
+		};
+		6EE537E82DBD631D0032EC12 /* MnemonicSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6EE537E72DBD631D0032EC12 /* XCRemoteSwiftPackageReference "MnemonicSwift" */;
+			productName = MnemonicSwift;
+		};
+		6EE537EA2DBD636F0032EC12 /* x-hd-wallet-api */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6EE537E32DBD5E360032EC12 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */;
+			productName = "x-hd-wallet-api";
+		};
+		6EE537F22DBD64D80032EC12 /* Base32 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6EE537F12DBD64D80032EC12 /* XCRemoteSwiftPackageReference "Base32" */;
+			productName = Base32;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.pbxproj
@@ -7,10 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6E0A054F2DC77745004A74E2 /* deterministicP256-swift in Frameworks */ = {isa = PBXBuildFile; productRef = 6E0A054E2DC77745004A74E2 /* deterministicP256-swift */; };
+		6E97FCC52DC0CD35006224B5 /* x-hd-wallet-api in Frameworks */ = {isa = PBXBuildFile; productRef = 6E97FCC42DC0CD35006224B5 /* x-hd-wallet-api */; };
 		6EE5379A2DAE75340032EC12 /* SwiftCBOR in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537992DAE75340032EC12 /* SwiftCBOR */; };
 		6EE537D92DAFA7AE0032EC12 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537D82DAFA7AE0032EC12 /* WebRTC */; };
 		6EE537DE2DAFC2540032EC12 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537DD2DAFC2540032EC12 /* Starscream */; };
-		6EE537E62DBD5E6A0032EC12 /* deterministicP256-swift in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537E52DBD5E6A0032EC12 /* deterministicP256-swift */; };
 		6EE537E92DBD631D0032EC12 /* MnemonicSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537E82DBD631D0032EC12 /* MnemonicSwift */; };
 		6EE537F32DBD64D80032EC12 /* Base32 in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE537F22DBD64D80032EC12 /* Base32 */; };
 /* End PBXBuildFile section */
@@ -62,9 +63,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				6EE537F32DBD64D80032EC12 /* Base32 in Frameworks */,
+				6E97FCC52DC0CD35006224B5 /* x-hd-wallet-api in Frameworks */,
 				6EE5379A2DAE75340032EC12 /* SwiftCBOR in Frameworks */,
+				6E0A054F2DC77745004A74E2 /* deterministicP256-swift in Frameworks */,
 				6EE537D92DAFA7AE0032EC12 /* WebRTC in Frameworks */,
-				6EE537E62DBD5E6A0032EC12 /* deterministicP256-swift in Frameworks */,
 				6EE537E92DBD631D0032EC12 /* MnemonicSwift in Frameworks */,
 				6EE537DE2DAFC2540032EC12 /* Starscream in Frameworks */,
 			);
@@ -138,9 +140,10 @@
 				6EE537992DAE75340032EC12 /* SwiftCBOR */,
 				6EE537D82DAFA7AE0032EC12 /* WebRTC */,
 				6EE537DD2DAFC2540032EC12 /* Starscream */,
-				6EE537E52DBD5E6A0032EC12 /* deterministicP256-swift */,
 				6EE537E82DBD631D0032EC12 /* MnemonicSwift */,
 				6EE537F22DBD64D80032EC12 /* Base32 */,
+				6E97FCC42DC0CD35006224B5 /* x-hd-wallet-api */,
+				6E0A054E2DC77745004A74E2 /* deterministicP256-swift */,
 			);
 			productName = "liquid-auth-ios";
 			productReference = 6E68E68C2DA924920087CB6D /* liquid-auth-ios.app */;
@@ -228,10 +231,10 @@
 				6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */,
 				6EE537D72DAFA7540032EC12 /* XCRemoteSwiftPackageReference "WebRTC" */,
 				6EE537DC2DAFC2540032EC12 /* XCRemoteSwiftPackageReference "Starscream" */,
-				6EE537E42DBD5E6A0032EC12 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */,
 				6EE537E72DBD631D0032EC12 /* XCRemoteSwiftPackageReference "MnemonicSwift" */,
 				6EE537F12DBD64D80032EC12 /* XCRemoteSwiftPackageReference "Base32" */,
 				6ECF13E52DBEBA73006E0BE0 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */,
+				6E0A054D2DC77745004A74E2 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6E68E68D2DA924920087CB6D /* Products */;
@@ -596,11 +599,19 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		6E0A054D2DC77745004A74E2 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/algorandfoundation/deterministic-P256-swift/";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		6ECF13E52DBEBA73006E0BE0 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/algorandfoundation/xHD-Wallet-API-swift/";
 			requirement = {
-				branch = main;
+				branch = "temp-branch-rawsign";
 				kind = branch;
 			};
 		};
@@ -628,14 +639,6 @@
 				minimumVersion = 4.0.8;
 			};
 		};
-		6EE537E42DBD5E6A0032EC12 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/algorandfoundation/deterministic-P256-swift";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 		6EE537E72DBD631D0032EC12 /* XCRemoteSwiftPackageReference "MnemonicSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Electric-Coin-Company/MnemonicSwift/";
@@ -655,6 +658,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		6E0A054E2DC77745004A74E2 /* deterministicP256-swift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6E0A054D2DC77745004A74E2 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */;
+			productName = "deterministicP256-swift";
+		};
+		6E97FCC42DC0CD35006224B5 /* x-hd-wallet-api */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6ECF13E52DBEBA73006E0BE0 /* XCRemoteSwiftPackageReference "xHD-Wallet-API-swift" */;
+			productName = "x-hd-wallet-api";
+		};
 		6EE537992DAE75340032EC12 /* SwiftCBOR */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6EE537972DAE74A10032EC12 /* XCRemoteSwiftPackageReference "SwiftCBOR" */;
@@ -669,11 +682,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6EE537DC2DAFC2540032EC12 /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
-		};
-		6EE537E52DBD5E6A0032EC12 /* deterministicP256-swift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6EE537E42DBD5E6A0032EC12 /* XCRemoteSwiftPackageReference "deterministic-P256-swift" */;
-			productName = "deterministicP256-swift";
 		};
 		6EE537E82DBD631D0032EC12 /* MnemonicSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "578a4d72f998b8770af25f520bbc1488e8e53274bef967576a2535a6b281c476",
+  "pins" : [
+    {
+      "identity" : "swiftcbor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/valpackett/SwiftCBOR",
+      "state" : {
+        "branch" : "master",
+        "revision" : "ea5ece79b0efde241495bfaa74eccceeffc382bc"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "32293b5e9e7bfa58d51d0809f1ea0608b760f92156c6ffa4cfc934f0cddca079",
+  "originHash" : "41ff925538ccfabd478b7f919ecf99bc5e5ff80af51a1c5b940ab68ec800b363",
   "pins" : [
     {
       "identity" : "base32",
@@ -40,10 +40,10 @@
     {
       "identity" : "deterministic-p256-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/algorandfoundation/deterministic-P256-swift",
+      "location" : "https://github.com/algorandfoundation/deterministic-P256-swift/",
       "state" : {
         "branch" : "main",
-        "revision" : "d8ac95b2bcc3830556027a1d90a103d713681883"
+        "revision" : "4fe03ee04894cb3dcf706b9e70a39588c1cec1c9"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/algorandfoundation/xHD-Wallet-API-swift/",
       "state" : {
-        "branch" : "main",
-        "revision" : "f5f1b560401490281dd0883b9b478e5d2cde834b"
+        "branch" : "temp-branch-rawsign",
+        "revision" : "e0b1553c43957de7fa0b3161a3d19ac1655cadca"
       }
     },
     {

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "578a4d72f998b8770af25f520bbc1488e8e53274bef967576a2535a6b281c476",
+  "originHash" : "6db90b9af3dd891711dcebca623b02b2cb2dae02e1703310c1c7c6003100ea95",
   "pins" : [
+    {
+      "identity" : "starscream",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/daltoniam/Starscream",
+      "state" : {
+        "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
+        "version" : "4.0.8"
+      }
+    },
     {
       "identity" : "swiftcbor",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,15 @@
       "state" : {
         "branch" : "master",
         "revision" : "ea5ece79b0efde241495bfaa74eccceeffc382bc"
+      }
+    },
+    {
+      "identity" : "webrtc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stasel/WebRTC",
+      "state" : {
+        "revision" : "e15b6945119ac4702b2ff6f770823341e1366ec8",
+        "version" : "135.0.0"
       }
     }
   ],

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,105 @@
 {
-  "originHash" : "6db90b9af3dd891711dcebca623b02b2cb2dae02e1703310c1c7c6003100ea95",
+  "originHash" : "fdf556dd2d56495e17691fc342be38cb1d099d81cc740250d1fe29c79db7ed38",
   "pins" : [
+    {
+      "identity" : "base32",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/norio-nomura/Base32",
+      "state" : {
+        "revision" : "c4bc0a49689999ae2c7c778f3830a6a6e694efb8",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "114343a705df4725dfe7ab8a2a326b8883cfd79c",
+        "version" : "5.5.1"
+      }
+    },
+    {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "729e01bc9b9dab466ac85f21fb9ee2bc1c61b258",
+        "version" : "1.8.4"
+      }
+    },
+    {
+      "identity" : "deterministic-p256-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/algorandfoundation/deterministic-P256-swift",
+      "state" : {
+        "branch" : "main",
+        "revision" : "d8ac95b2bcc3830556027a1d90a103d713681883"
+      }
+    },
+    {
+      "identity" : "jsonschema.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/algorandfoundation/JSONSchema.swift.git",
+      "state" : {
+        "revision" : "92385c024dee684e0b6b9dee6ee067844bf61f38",
+        "version" : "0.7.0"
+      }
+    },
+    {
+      "identity" : "messagepack.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/a2/MessagePack.swift.git",
+      "state" : {
+        "revision" : "27b35fd49e92fcae395bf8ccb233499d89cc7890",
+        "version" : "4.0.0"
+      }
+    },
+    {
+      "identity" : "mnemonicswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Electric-Coin-Company/MnemonicSwift.git",
+      "state" : {
+        "revision" : "2d7f3e76e904621e111efada6cc9575f39543bb2",
+        "version" : "2.2.5"
+      }
+    },
+    {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit.git",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "eb6656ed26bdef967ad8d07c27e2eab34dc582f2",
+        "version" : "0.37.0"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
     {
       "identity" : "starscream",
       "kind" : "remoteSourceControl",
@@ -8,6 +107,42 @@
       "state" : {
         "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
         "version" : "4.0.8"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "60f13f60c4d093691934dc6cfdf5f508ada1f894",
+        "version" : "2.6.0"
+      }
+    },
+    {
+      "identity" : "swift-sodium-full",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/algorandfoundation/swift-sodium-full.git",
+      "state" : {
+        "revision" : "4859e76668cdf80e0b01d76eaf0c70d50e1f1bd9",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "1103c45ece4f7fe160b8f75b4ea1ee2e5fac1841",
+        "version" : "601.0.0"
       }
     },
     {
@@ -20,12 +155,57 @@
       }
     },
     {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "revision" : "625792423014cc49b0a1e5a1a5c0d6b8b3de10f9",
+        "version" : "0.59.1"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
       "identity" : "webrtc",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stasel/WebRTC",
       "state" : {
         "revision" : "e15b6945119ac4702b2ff6f770823341e1366ec8",
         "version" : "135.0.0"
+      }
+    },
+    {
+      "identity" : "xhd-wallet-api-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/algorandfoundation/xHD-Wallet-API-swift",
+      "state" : {
+        "branch" : "main",
+        "revision" : "e5577ca2df787cef16f415c6d3c3cdee7bfc2d75"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "b4b8042411dc7bbb696300a34a4bf3ba1b7ad19b",
+        "version" : "5.3.1"
       }
     }
   ],

--- a/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/liquid-auth-ios/liquid-auth-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fdf556dd2d56495e17691fc342be38cb1d099d81cc740250d1fe29c79db7ed38",
+  "originHash" : "32293b5e9e7bfa58d51d0809f1ea0608b760f92156c6ffa4cfc934f0cddca079",
   "pins" : [
     {
       "identity" : "base32",
@@ -193,10 +193,10 @@
     {
       "identity" : "xhd-wallet-api-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/algorandfoundation/xHD-Wallet-API-swift",
+      "location" : "https://github.com/algorandfoundation/xHD-Wallet-API-swift/",
       "state" : {
         "branch" : "main",
-        "revision" : "e5577ca2df787cef16f415c6d3c3cdee7bfc2d75"
+        "revision" : "f5f1b560401490281dd0883b9b478e5d2cde834b"
       }
     },
     {

--- a/liquid-auth-ios/liquid-auth-ios/AttestationApi.swift
+++ b/liquid-auth-ios/liquid-auth-ios/AttestationApi.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 class AttestationApi {
     private let session: URLSession
@@ -75,7 +76,8 @@ class AttestationApi {
         liquidExt: [String: Any]? = nil,
         completion: @escaping (Result<Data, Error>) -> Void
     ) {
-        let path = "\(origin)/attestation/response"
+        // TODO: We are assuming that the request is over HTTPS
+        let path = "https://\(origin)/attestation/response"
         guard let url = URL(string: path) else {
             completion(.failure(NSError(domain: "Invalid URL", code: -1, userInfo: nil)))
             return
@@ -84,8 +86,12 @@ class AttestationApi {
         // Construct the payload
         var payload = credential
         if let liquidExt = liquidExt {
-            payload["clientExtensionResults"] = ["liquid": liquidExt]
+            let clientExtensionResults: [String: Any] = ["liquid": liquidExt]
+            payload["clientExtensionResults"] = clientExtensionResults
         }
+
+        // Add device information
+        payload["device"] = UIDevice.current.model
 
         guard let body = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
             completion(.failure(NSError(domain: "Invalid JSON", code: -1, userInfo: nil)))

--- a/liquid-auth-ios/liquid-auth-ios/AttestationApi.swift
+++ b/liquid-auth-ios/liquid-auth-ios/AttestationApi.swift
@@ -92,6 +92,8 @@ class AttestationApi {
 
         // Add device information
         payload["device"] = UIDevice.current.model
+        
+        print("the full payload: \(payload)")
 
         guard let body = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
             completion(.failure(NSError(domain: "Invalid JSON", code: -1, userInfo: nil)))

--- a/liquid-auth-ios/liquid-auth-ios/AttestationApi.swift
+++ b/liquid-auth-ios/liquid-auth-ios/AttestationApi.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+class AttestationApi {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    /**
+     * POST request to retrieve PublicKeyCredentialCreationOptions
+     *
+     * @param origin - Base URL for the service
+     * @param userAgent - User Agent for FIDO Server parsing
+     * @param options - PublicKeyCredentialCreationOptions in JSON
+     */
+    func postAttestationOptions(
+        origin: String,
+        userAgent: String,
+        options: [String: Any],
+        completion: @escaping (Result<(Data, HTTPCookie?), Error>) -> Void
+    ) {
+        // TODO: We are assuming the origin is an HTTPS URL. This should be validated.
+        let path = "https://\(origin)/attestation/request"
+        guard let url = URL(string: path) else {
+            completion(.failure(NSError(domain: "Invalid URL", code: -1, userInfo: nil)))
+            return
+        }
+
+        // Convert options dictionary to JSON data
+        guard let body = try? JSONSerialization.data(withJSONObject: options, options: []) else {
+            completion(.failure(NSError(domain: "Invalid JSON", code: -1, userInfo: nil)))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.httpBody = body
+
+        // Perform the request
+        let task = session.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  let data = data else {
+                completion(.failure(NSError(domain: "Invalid response", code: -1, userInfo: nil)))
+                return
+            }
+
+            // Extract cookies from the response
+            let cookies = HTTPCookie.cookies(withResponseHeaderFields: httpResponse.allHeaderFields as! [String: String], for: url)
+            let sessionCookie = cookies.first(where: { $0.name == "session" })
+
+            completion(.success((data, sessionCookie)))
+        }
+
+        task.resume()
+    }
+
+    /**
+     * POST request to register a PublicKeyCredential
+     *
+     * @param origin - Base URL for the service
+     * @param userAgent - User Agent for FIDO Server parsing
+     * @param credential - PublicKeyCredential from Authenticator Response
+     * @param liquidExt - Optional Liquid extension data
+     */
+    func postAttestationResult(
+        origin: String,
+        userAgent: String,
+        credential: [String: Any],
+        liquidExt: [String: Any]? = nil,
+        completion: @escaping (Result<Data, Error>) -> Void
+    ) {
+        let path = "\(origin)/attestation/response"
+        guard let url = URL(string: path) else {
+            completion(.failure(NSError(domain: "Invalid URL", code: -1, userInfo: nil)))
+            return
+        }
+
+        // Construct the payload
+        var payload = credential
+        if let liquidExt = liquidExt {
+            payload["clientExtensionResults"] = ["liquid": liquidExt]
+        }
+
+        guard let body = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
+            completion(.failure(NSError(domain: "Invalid JSON", code: -1, userInfo: nil)))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.httpBody = body
+
+        // Perform the request
+        let task = session.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let data = data else {
+                completion(.failure(NSError(domain: "Invalid response", code: -1, userInfo: nil)))
+                return
+            }
+
+            completion(.success(data))
+        }
+
+        task.resume()
+    }
+}

--- a/liquid-auth-ios/liquid-auth-ios/AttestationApi.swift
+++ b/liquid-auth-ios/liquid-auth-ios/AttestationApi.swift
@@ -20,14 +20,13 @@ class AttestationApi {
         options: [String: Any],
         completion: @escaping (Result<(Data, HTTPCookie?), Error>) -> Void
     ) {
-        // TODO: We are assuming the origin is an HTTPS URL. This should be validated.
+        // TODO: We are assuming that the request is over HTTPS
         let path = "https://\(origin)/attestation/request"
         guard let url = URL(string: path) else {
             completion(.failure(NSError(domain: "Invalid URL", code: -1, userInfo: nil)))
             return
         }
 
-        // Convert options dictionary to JSON data
         guard let body = try? JSONSerialization.data(withJSONObject: options, options: []) else {
             completion(.failure(NSError(domain: "Invalid JSON", code: -1, userInfo: nil)))
             return
@@ -39,7 +38,6 @@ class AttestationApi {
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         request.httpBody = body
 
-        // Perform the request
         let task = session.dataTask(with: request) { data, response, error in
             if let error = error {
                 completion(.failure(error))
@@ -47,14 +45,14 @@ class AttestationApi {
             }
 
             guard let httpResponse = response as? HTTPURLResponse,
-                  let data = data else {
+                let data = data else {
                 completion(.failure(NSError(domain: "Invalid response", code: -1, userInfo: nil)))
                 return
             }
 
-            // Extract cookies from the response
+            // Extract the cookie
             let cookies = HTTPCookie.cookies(withResponseHeaderFields: httpResponse.allHeaderFields as! [String: String], for: url)
-            let sessionCookie = cookies.first(where: { $0.name == "session" })
+            let sessionCookie = cookies.first(where: { $0.name == "connect.sid" })
 
             completion(.success((data, sessionCookie)))
         }

--- a/liquid-auth-ios/liquid-auth-ios/AuthenticatorData.swift
+++ b/liquid-auth-ios/liquid-auth-ios/AuthenticatorData.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+
+// struct AuthenticatorData {
+    
+//     init() {}
+    
+//     func toData() -> Data {
+//         return Data()
+//     }
+// }
+
+struct AuthenticatorData: Codable {
+   let rpIdHash: Data
+   let userPresent: Bool
+   let userVerified: Bool
+   let atIncluded: Bool
+   let edIncluded: Bool
+   var signCount: UInt32 // 32-bit unsigned big-endian integer
+   let attestedCredentialData: Data?
+   let extensions: Data?
+
+   // Define these as static constants
+   static let upMask: UInt8 = 1      // User present result
+   static let uvMask: UInt8 = 1 << 2 // User verified result
+   static let atMask: UInt8 = 1 << 6 // Attested credential data included
+   static let edMask: UInt8 = 1 << 7 // Extension data included
+
+   init(_ rpIdHash: Data, _ up: Bool, _ uv: Bool, _ count: UInt32,
+        _ attestedCredData: Data?, _ extensions: Data?) {
+       self.rpIdHash = rpIdHash
+       self.userPresent = up
+       self.userVerified = uv
+       self.atIncluded = attestedCredData != nil ? true : false
+       self.edIncluded = extensions != nil
+       self.signCount = count
+       self.attestedCredentialData = attestedCredData
+       self.extensions = extensions
+   }
+
+   func createFlags(up userPresent: Bool, uv userVerified: Bool, at atIncluded: Bool, ed edIncluded: Bool) -> UInt8 {
+       var flags: UInt8 = 0
+       if userPresent { flags = flags | AuthenticatorData.upMask }
+       if userVerified { flags = flags | AuthenticatorData.uvMask }
+       if atIncluded { flags = flags | AuthenticatorData.atMask }
+       if edIncluded { flags = flags | AuthenticatorData.edMask }
+       return flags
+   }
+
+   func toData() -> Data {
+       let flags = self.createFlags(up: self.userPresent, uv: self.userVerified, at: self.atIncluded, ed: self.edIncluded)
+       let flagsData = flags.toData()
+       let signCountData = self.signCount.toDataBigEndian()
+       var data = rpIdHash + flagsData + signCountData
+       if let attestedCredentialData = self.attestedCredentialData {
+           data += attestedCredentialData
+       }
+       if let extensions = self.extensions {
+           data += extensions
+       }
+       return data
+   }
+}

--- a/liquid-auth-ios/liquid-auth-ios/ContentView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/ContentView.swift
@@ -248,6 +248,7 @@ struct ContentView: View {
                                         "requestId": requestId,
                                         "address": address,
                                         "signature": sig.base64URLEncodedString(),
+                                        "device": UIDevice.current.model,
                                     ]
                                     print("Created liquidExt JSON object: \(liquidExt)")
                                     

--- a/liquid-auth-ios/liquid-auth-ios/ContentView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/ContentView.swift
@@ -338,11 +338,16 @@ struct ContentView: View {
                                         DispatchQueue.main.async {
                                             switch result {
                                             case .success(let data):
-                                                print("Attestation result posted: \(String(data: data, encoding: .utf8) ?? "Invalid response")")
+                                                let responseString = String(data: data, encoding: .utf8) ?? "Invalid response"
+                                                print("Attestation result posted: \(responseString)")
+                                                self.scannedMessage = "Attestation result successfully posted: \(responseString)"
+                                                self.errorMessage = nil
                                             case .failure(let error):
                                                 print("Failed to post attestation result: \(error)")
                                                 self.errorMessage = "Failed to post attestation result: \(error.localizedDescription)"
+                                                self.scannedMessage = nil
                                             }
+                                            self.isLoading = false
                                         }
                                     }
                                 } else {

--- a/liquid-auth-ios/liquid-auth-ios/ContentView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AVFoundation
+import UIKit
 
 struct ContentView: View {
     @State private var isScanning = false
@@ -46,7 +47,36 @@ struct ContentView: View {
     private func handleScannedCode(_ code: String) {
         if code.starts(with: "FIDO:/") {
             // Decode the FIDO URI
-            if let fidoRequest = FIDOHandler.decodeFIDOURI(code) {
+
+            // We need to look into hybrid transport for iOS to understand how to properly
+            // handle the FIDO URI. The current implementation is a placeholder.
+            scannedMessage = "FIDO URI detected. Processing..."
+            errorMessage = nil
+
+            // Attempt to open the URI using UIApplication
+            
+            /*
+             guard let url = URL(string: code) else {
+                errorMessage = "Invalid URI format."
+                scannedMessage = nil
+                return
+            }
+            
+            UIApplication.shared.open(url, options: [:]) { success in
+                    if success {
+                        scannedMessage = "Opened URI: \(code)"
+                        errorMessage = nil
+                    } else {
+                        errorMessage = "Failed to open URI: \(code)"
+                        scannedMessage = nil
+                    }
+                } 
+            */
+
+
+            // This is how to decode the FIDO URI and extract the contents
+            /*
+             if let fidoRequest = FIDOHandler.decodeFIDOURI(code) {
                 // Determine the flow type
                 scannedMessage = "\(fidoRequest.flowType) flow detected. Ready to proceed."
 
@@ -69,6 +99,7 @@ struct ContentView: View {
                 errorMessage = "Failed to process FIDO URI."
                 scannedMessage = nil
             }
+            */
         } else if code.starts(with: "liquid://") {
             // Handle Liquid Auth URI
             handleLiquidAuthURI(code)
@@ -84,6 +115,50 @@ struct ContentView: View {
         errorMessage = nil
         // Add logic to decode and process the Liquid Auth message
         print("Handling Liquid Auth URI: \(uri)")
+
+        if let (origin, requestId) = Utility.extractOriginAndRequestId(from: uri) {
+            print("Origin: \(origin), Request ID: \(requestId)")
+
+            // TODO: check if credential for the specific origin already exists
+            // For now, only register:
+
+            if (true) {
+                register(origin: origin, requestId: requestId)
+            }
+            // TODO: If yes, authenticate with the credential
+            
+        } else {
+            print("Failed to extract origin and request ID.")
+        }
+    }
+
+    private func register(origin: String, requestId: String) {
+        // Get the appropriate Algorand wallet address
+        let address = "ABC"
+
+        // Construct the options JSON object
+        
+        let attestationApi = AttestationApi()
+        let options: [String: Any] = [
+            "username": address,
+            "displayName": "Liquid Auth User",
+            "authenticatorSelection": ["userVerification": "required"],
+            "extensions": ["liquid": true]
+        ]
+        let userAgent = Utility.getUserAgent()
+
+        attestationApi.postAttestationOptions(origin: origin, userAgent: userAgent, options: options) { result in
+            switch result {
+            case .success(let (data, sessionCookie)):
+                print("Response data: \(String(data: data, encoding: .utf8) ?? "Invalid data")")
+                if let cookie = sessionCookie {
+                    print("Session cookie: \(cookie)")
+                }
+            case .failure(let error):
+                print("Error: \(error)")
+            }
+        }
+        
     }
 }
 

--- a/liquid-auth-ios/liquid-auth-ios/ContentView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/ContentView.swift
@@ -195,20 +195,22 @@ struct ContentView: View {
                         if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
                         let challengeBase64 = json["challenge"] as? String {
                             print("Challenge (Base64): \(challengeBase64)")
-                            
+                            print("Challenge Decoded: \([UInt8](Utility.decodeBase64Url(challengeBase64)!))")
+                            print("Challenge JSON: \(Utility.decodeBase64UrlToJSON(challengeBase64) ?? "nil")")
                             do {
-                                let schema = try Schema(filePath: "liquid-auth-ios/liquid-auth-ios/auth.request.json")
+                                let schema = try Schema(filePath: Bundle.main.path(forResource: "auth.request", ofType: "json")!)
                                 
                                 let sig = try wallet?.signData(
                                     context: KeyContext.Address,
                                     account: 0,
                                     change: 0,
                                     keyIndex: 0,
-                                    data: Utility.decodeBase64Url(challengeBase64)!,
-                                    metadata: SignMetadata(customEncoding: Encoding.base64, customSchema: schema)
+                                    data: Data(Utility.decodeBase64UrlToJSON(challengeBase64)!.utf8),
+                                    metadata: SignMetadata(encoding: Encoding.none, schema: schema)
                                 )
                                 
                                 print("Signature: " + "\(sig?.base64EncodedString() ?? "nil")")
+                                print("Signature Length (Raw Bytes): \(sig?.count ?? -1)")
                             } catch {
                                 print("Failed to load schema: \(error)")
                             }

--- a/liquid-auth-ios/liquid-auth-ios/ContentView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/ContentView.swift
@@ -171,8 +171,6 @@ struct ContentView: View {
             }
             
             let address = try Utility.encodeAddress(bytes: pk)
-            
-            print("Address: \(address)")
 
             let attestationApi = AttestationApi()
 

--- a/liquid-auth-ios/liquid-auth-ios/ContentView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/ContentView.swift
@@ -233,7 +233,7 @@ struct ContentView: View {
 
                                 // Dangerous to expose rawSign like this
                                 if let sig = try Ed25519Wallet?.rawSign(
-                                    bip44Path: [0x8000_0000 + 0, 0x8000_0000 + 283, 0x8000_0000 + 0, 0, 0],
+                                    bip44Path: [0x8000_0000 + 44, 0x8000_0000 + 283, 0x8000_0000 + 0, 0, 0],
                                     message: Data([UInt8](Utility.decodeBase64Url(challengeBase64Url)!)),
                                     derivationType: BIP32DerivationType.Peikert
                                 ) {

--- a/liquid-auth-ios/liquid-auth-ios/ContentView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/ContentView.swift
@@ -200,14 +200,17 @@ struct ContentView: View {
                             do {
                                 let schema = try Schema(filePath: Bundle.main.path(forResource: "auth.request", ofType: "json")!)
                                 
-                                let sig = try wallet?.signData(
-                                    context: KeyContext.Address,
-                                    account: 0,
-                                    change: 0,
-                                    keyIndex: 0,
-                                    data: Data(Utility.decodeBase64UrlToJSON(challengeBase64)!.utf8),
-                                    metadata: SignMetadata(encoding: Encoding.none, schema: schema)
-                                )
+//                                let sig = try wallet?.signData(
+//                                    context: KeyContext.Address,
+//                                    account: 0,
+//                                    change: 0,
+//                                    keyIndex: 0,
+//                                    data: Data(Utility.decodeBase64UrlToJSON(challengeBase64)!.utf8),
+//                                    metadata: SignMetadata(encoding: Encoding.none, schema: schema)
+//                                )
+//
+                                // TODO: FIX THIS! Incredibly dangerous to expose rawSign like this without any data validation We need to address the data validation JSON issues that both xHD-Wallet-API-Swift and Kotlin suffer from
+                                let sig = try wallet?.rawSign(bip44Path: [0x8000_0000 + 0,  0x8000_0000 + 283,  0x8000_0000 + 0, 0, 0], message: Data([UInt8](Utility.decodeBase64Url(challengeBase64)!)), derivationType: BIP32DerivationType.Peikert)
                                 
                                 print("Signature: " + "\(sig?.base64EncodedString() ?? "nil")")
                                 print("Signature Length (Raw Bytes): \(sig?.count ?? -1)")

--- a/liquid-auth-ios/liquid-auth-ios/ContentView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/ContentView.swift
@@ -1,15 +1,10 @@
-//
-//  ContentView.swift
-//  liquid-auth-ios
-//
-//  Created by Yared Efrem Afework on 2025-04-11.
-//
-
 import SwiftUI
 import AVFoundation
 
 struct ContentView: View {
     @State private var isScanning = false
+    @State private var scannedMessage: String? = nil
+    @State private var errorMessage: String? = nil
 
     var body: some View {
         VStack {
@@ -29,12 +24,66 @@ struct ContentView: View {
             }
             .sheet(isPresented: $isScanning) {
                 QRCodeScannerView { scannedCode in
-                    print("Scanned QR Code: \(scannedCode)")
+                    handleScannedCode(scannedCode)
                     isScanning = false
                 }
             }
+
+            if let message = scannedMessage {
+                Text("Message: \(message)")
+                    .padding()
+            }
+
+            if let error = errorMessage {
+                Text("Error: \(error)")
+                    .foregroundColor(.red)
+                    .padding()
+            }
         }
         .padding()
+    }
+
+    private func handleScannedCode(_ code: String) {
+        if code.starts(with: "FIDO:/") {
+            // Decode the FIDO URI
+            if let fidoRequest = FIDOHandler.decodeFIDOURI(code) {
+                // Determine the flow type
+                scannedMessage = "\(fidoRequest.flowType) flow detected. Ready to proceed."
+
+                // Log the extracted fields
+                print("Public Key: \(fidoRequest.publicKey)")
+                print("QR Secret: \(fidoRequest.qrSecret)")
+                print("Tunnel Server Count: \(fidoRequest.tunnelServerCount)")
+                if let currentTime = fidoRequest.currentTime {
+                    print("Current Time: \(currentTime)")
+                }
+                if let stateAssisted = fidoRequest.stateAssisted {
+                    print("State-Assisted Transactions: \(stateAssisted)")
+                }
+                if let hint = fidoRequest.hint {
+                    print("Hint: \(hint)")
+                }
+
+                errorMessage = nil
+            } else {
+                errorMessage = "Failed to process FIDO URI."
+                scannedMessage = nil
+            }
+        } else if code.starts(with: "liquid://") {
+            // Handle Liquid Auth URI
+            handleLiquidAuthURI(code)
+        } else {
+            errorMessage = "Unsupported QR code format."
+            scannedMessage = nil
+        }
+    }
+
+    private func handleLiquidAuthURI(_ uri: String) {
+        // Example: Decode the Liquid Auth URI
+        scannedMessage = "Liquid Auth URI: \(uri)"
+        errorMessage = nil
+        // Add logic to decode and process the Liquid Auth message
+        print("Handling Liquid Auth URI: \(uri)")
     }
 }
 

--- a/liquid-auth-ios/liquid-auth-ios/FIDOHandler.swift
+++ b/liquid-auth-ios/liquid-auth-ios/FIDOHandler.swift
@@ -1,0 +1,137 @@
+import Foundation
+import SwiftCBOR
+
+struct FIDOHandler {
+    /// Decodes a FIDO URI and returns a `FIDORequest` instance.
+    static func decodeFIDOURI(_ uri: String) -> FIDORequest? {
+        guard uri.starts(with: "FIDO:/") else {
+            print("Invalid FIDO URI.")
+            return nil
+        }
+
+        // Extract the base10-encoded string
+        let base10String = String(uri.dropFirst("FIDO:/".count))
+
+        // Decode the base10 string into bytes
+        guard let decodedBytes = decodeBase10String(base10String) else {
+            print("Failed to decode base10 string.")
+            return nil
+        }
+
+        // Decode the bytes into a CBOR object
+        guard let cborObject = decodeCBOR(from: decodedBytes) else {
+            print("Failed to decode CBOR.")
+            return nil
+        }
+
+        // Ensure the CBOR object is a map
+        guard case let CBOR.map(cborMap) = cborObject else {
+            print("Invalid CBOR structure. Expected a map but got: \(cborObject)")
+            return nil
+        }
+
+        // Extract relevant fields from the CBOR map
+        guard let publicKeyBytes = cborMap[CBOR.unsignedInt(0)]?.byteStringValue,
+              let qrSecret = cborMap[CBOR.unsignedInt(1)]?.byteStringValue,
+              let tunnelServerCount = cborMap[CBOR.unsignedInt(2)]?.unsignedIntValue else {
+            print("Missing required fields in CBOR.")
+            return nil
+        }
+
+        // Optional fields
+        let currentTime = cborMap[CBOR.unsignedInt(3)]?.unsignedIntValue
+        let stateAssisted = cborMap[CBOR.unsignedInt(4)]?.booleanValue
+        let hint = cborMap[CBOR.unsignedInt(5)]?.stringValue
+
+        // Create and return a FIDORequest instance
+        return FIDORequest(
+            publicKey: publicKeyBytes,
+            qrSecret: qrSecret,
+            tunnelServerCount: tunnelServerCount,
+            currentTime: currentTime,
+            stateAssisted: stateAssisted,
+            hint: hint
+        )
+    }
+
+    /// Decodes a base10-encoded string into bytes.
+    private static func decodeBase10String(_ input: String) -> [UInt8]? {
+        var bytes: [UInt8] = []
+
+        // Split the input into chunks of up to 17 digits
+        let chunks = stride(from: 0, to: input.count, by: 17).map {
+            let start = input.index(input.startIndex, offsetBy: $0)
+            let end = input.index(start, offsetBy: min(17, input.count - $0))
+            return String(input[start..<end])
+        }
+
+        for chunk in chunks {
+            guard let number = UInt64(chunk) else {
+                print("Invalid chunk: \(chunk)")
+                return nil
+            }
+
+            // Determine the number of bytes in the chunk
+            let byteCount: Int
+            switch chunk.count {
+            case 3: byteCount = 1
+            case 5: byteCount = 2
+            case 8: byteCount = 3
+            case 10: byteCount = 4
+            case 13: byteCount = 5
+            case 15: byteCount = 6
+            case 17: byteCount = 7
+            default:
+                print("Invalid chunk length: \(chunk.count)")
+                return nil
+            }
+
+            // Convert the number to bytes and append the relevant bytes
+            let chunkBytes = withUnsafeBytes(of: number.littleEndian) { Array($0) }
+            bytes.append(contentsOf: chunkBytes.prefix(byteCount))
+        }
+
+        return bytes
+    }
+
+    /// Decodes a byte array into a CBOR object.
+    private static func decodeCBOR(from bytes: [UInt8]) -> Any? {
+        do {
+            let cborObject = try CBORDecoder(input: bytes).decodeItem()
+            return cborObject
+        } catch {
+            print("CBOR decoding failed: \(error)")
+            return nil
+        }
+    }
+}
+
+private extension CBOR {
+    var byteStringValue: [UInt8]? {
+        if case let .byteString(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    var unsignedIntValue: UInt64? {
+        if case let .unsignedInt(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    var booleanValue: Bool? {
+        if case let .boolean(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    var stringValue: String? {
+        if case let .utf8String(value) = self {
+            return value
+        }
+        return nil
+    }
+}

--- a/liquid-auth-ios/liquid-auth-ios/FIDORequest.swift
+++ b/liquid-auth-ios/liquid-auth-ios/FIDORequest.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+// https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#hybrid-qr-initiated
+struct FIDORequest {
+    let publicKey: [UInt8]
+    let qrSecret: [UInt8]
+    let tunnelServerCount: UInt64
+    let currentTime: UInt64?
+    let stateAssisted: Bool?
+    let hint: String?
+
+    /// Determines if the flow is MakeCredential or GetAssertion based on the hint.
+    var flowType: String {
+        switch hint {
+        case "mc":
+            return "MakeCredential"
+        case "ga":
+            return "GetAssertion"
+        default:
+            return "Unknown"
+        }
+    }
+}

--- a/liquid-auth-ios/liquid-auth-ios/QRCodeScannerView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/QRCodeScannerView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AVFoundation
+import UIKit
 
 struct QRCodeScannerView: UIViewControllerRepresentable {
     class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
@@ -13,6 +14,11 @@ struct QRCodeScannerView: UIViewControllerRepresentable {
             if let metadataObject = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
                metadataObject.type == .qr,
                let stringValue = metadataObject.stringValue {
+                // Trigger haptic feedback
+                let generator = UIImpactFeedbackGenerator(style: .medium)
+                generator.impactOccurred()
+
+                // Call the parent handler
                 parent.didFindCode(stringValue)
             }
         }

--- a/liquid-auth-ios/liquid-auth-ios/QRCodeScannerView.swift
+++ b/liquid-auth-ios/liquid-auth-ios/QRCodeScannerView.swift
@@ -5,15 +5,20 @@ import UIKit
 struct QRCodeScannerView: UIViewControllerRepresentable {
     class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         var parent: QRCodeScannerView
+        var captureSession: AVCaptureSession?
 
-        init(parent: QRCodeScannerView) {
+        init(parent: QRCodeScannerView, captureSession: AVCaptureSession) {
             self.parent = parent
+            self.captureSession = captureSession
         }
 
         func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
             if let metadataObject = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
                metadataObject.type == .qr,
                let stringValue = metadataObject.stringValue {
+                // Stop the capture session to prevent repeated scans
+                captureSession?.stopRunning()
+
                 // Trigger haptic feedback
                 let generator = UIImpactFeedbackGenerator(style: .medium)
                 generator.impactOccurred()
@@ -27,31 +32,32 @@ struct QRCodeScannerView: UIViewControllerRepresentable {
     var didFindCode: (String) -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(parent: self)
+        let captureSession = AVCaptureSession()
+        return Coordinator(parent: self, captureSession: captureSession)
     }
 
     func makeUIViewController(context: Context) -> UIViewController {
         let viewController = UIViewController()
-        let captureSession = AVCaptureSession()
+        let captureSession = context.coordinator.captureSession
 
         guard let videoCaptureDevice = AVCaptureDevice.default(for: .video) else { return viewController }
         let videoInput = try? AVCaptureDeviceInput(device: videoCaptureDevice)
         if let videoInput = videoInput {
-            captureSession.addInput(videoInput)
+            captureSession?.addInput(videoInput)
         }
 
         let metadataOutput = AVCaptureMetadataOutput()
-        captureSession.addOutput(metadataOutput)
+        captureSession?.addOutput(metadataOutput)
 
         metadataOutput.setMetadataObjectsDelegate(context.coordinator, queue: DispatchQueue.main)
         metadataOutput.metadataObjectTypes = [.qr]
 
-        let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+        let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession!)
         previewLayer.frame = viewController.view.layer.bounds
         previewLayer.videoGravity = .resizeAspectFill
         viewController.view.layer.addSublayer(previewLayer)
 
-        captureSession.startRunning()
+        captureSession?.startRunning()
 
         return viewController
     }

--- a/liquid-auth-ios/liquid-auth-ios/SHA512_256.swift
+++ b/liquid-auth-ios/liquid-auth-ios/SHA512_256.swift
@@ -1,0 +1,280 @@
+//
+//  CryptoUtility.swift
+//  liquid-auth-ios
+//
+//  Created by Yared Efrem Afework on 2025-04-26.
+//
+
+// Modified off of Matan Lachmish's Cryptography repo
+// https://github.com/mlachmish/Cryptography/ MIT License
+//
+// SHA2 [.] swift
+//  Cryptography
+//
+//  Created by Matan Lachmish on 25/07/2016.
+//  Copyright © 2016 The Big Fat Ninja. All rights reserved.
+//
+
+import Foundation
+
+// swiftlint:disable variable_name
+// swiftlint:disable line_length
+// swiftlint:disable comma
+
+public struct SHA512_256 {
+    public func hash(_ message: [UInt8]) -> [UInt8] {
+        SHA2.hash64Bit(message: message)
+    }
+}
+
+public let blockSize: Int = 128
+
+let h: [UInt64] = [0x2231_2194_FC2B_F72C, 0x9F55_5FA3_C84C_64C2, 0x2393_B86B_6F53_B151, 0x9638_7719_5940_EABD,
+                   0x9628_3EE2_A88E_FFE3, 0xBE5E_1E25_5386_3992, 0x2B01_99FC_2C85_B8AA, 0x0EB7_2DDC_81C5_2CA2]
+
+let k: [UInt64] = [0x428A_2F98_D728_AE22, 0x7137_4491_23EF_65CD, 0xB5C0_FBCF_EC4D_3B2F, 0xE9B5_DBA5_8189_DBBC, 0x3956_C25B_F348_B538,
+                   0x59F1_11F1_B605_D019, 0x923F_82A4_AF19_4F9B, 0xAB1C_5ED5_DA6D_8118, 0xD807_AA98_A303_0242, 0x1283_5B01_4570_6FBE,
+                   0x2431_85BE_4EE4_B28C, 0x550C_7DC3_D5FF_B4E2, 0x72BE_5D74_F27B_896F, 0x80DE_B1FE_3B16_96B1, 0x9BDC_06A7_25C7_1235,
+                   0xC19B_F174_CF69_2694, 0xE49B_69C1_9EF1_4AD2, 0xEFBE_4786_384F_25E3, 0x0FC1_9DC6_8B8C_D5B5, 0x240C_A1CC_77AC_9C65,
+                   0x2DE9_2C6F_592B_0275, 0x4A74_84AA_6EA6_E483, 0x5CB0_A9DC_BD41_FBD4, 0x76F9_88DA_8311_53B5, 0x983E_5152_EE66_DFAB,
+                   0xA831_C66D_2DB4_3210, 0xB003_27C8_98FB_213F, 0xBF59_7FC7_BEEF_0EE4, 0xC6E0_0BF3_3DA8_8FC2, 0xD5A7_9147_930A_A725,
+                   0x06CA_6351_E003_826F, 0x1429_2967_0A0E_6E70, 0x27B7_0A85_46D2_2FFC, 0x2E1B_2138_5C26_C926, 0x4D2C_6DFC_5AC4_2AED,
+                   0x5338_0D13_9D95_B3DF, 0x650A_7354_8BAF_63DE, 0x766A_0ABB_3C77_B2A8, 0x81C2_C92E_47ED_AEE6, 0x9272_2C85_1482_353B,
+                   0xA2BF_E8A1_4CF1_0364, 0xA81A_664B_BC42_3001, 0xC24B_8B70_D0F8_9791, 0xC76C_51A3_0654_BE30, 0xD192_E819_D6EF_5218,
+                   0xD699_0624_5565_A910, 0xF40E_3585_5771_202A, 0x106A_A070_32BB_D1B8, 0x19A4_C116_B8D2_D0C8, 0x1E37_6C08_5141_AB53,
+                   0x2748_774C_DF8E_EB99, 0x34B0_BCB5_E19B_48A8, 0x391C_0CB3_C5C9_5A63, 0x4ED8_AA4A_E341_8ACB, 0x5B9C_CA4F_7763_E373,
+                   0x682E_6FF3_D6B2_B8A3, 0x748F_82EE_5DEF_B2FC, 0x78A5_636F_4317_2F60, 0x84C8_7814_A1F0_AB72, 0x8CC7_0208_1A64_39EC,
+                   0x90BE_FFFA_2363_1E28, 0xA450_6CEB_DE82_BDE9, 0xBEF9_A3F7_B2C6_7915, 0xC671_78F2_E372_532B, 0xCA27_3ECE_EA26_619C,
+                   0xD186_B8C7_21C0_C207, 0xEADA_7DD6_CDE0_EB1E, 0xF57D_4F7F_EE6E_D178, 0x06F0_67AA_7217_6FBA, 0x0A63_7DC5_A2C8_98A6,
+                   0x113F_9804_BEF9_0DAE, 0x1B71_0B35_131C_471B, 0x28DB_77F5_2304_7D84, 0x32CA_AB7B_40C7_2493, 0x3C9E_BE0A_15C9_BEBC,
+                   0x431D_67C4_9C10_0D4C, 0x4CC5_D4BE_CB3E_42B6, 0x597F_299C_FC65_7E2A, 0x5FCB_6FAB_3AD6_FAEC, 0x6C44_198C_4A47_5817]
+
+func truncateResult<T>(h: [T]) -> ArraySlice<T> {
+    h[0 ..< 4]
+}
+
+// swiftlint:enable variable_name
+// swiftlint:enable line_length
+// swiftlint:enable comma
+
+enum SHA2 {
+    private static func preprocessMessage(message: [UInt8],
+                                          messageLengthBits: Int) -> [UInt8]
+    {
+        var preprocessedMessage = message
+        // Pre-processing: adding a single 1 bit
+        // Notice: the input bytes are considered as bits strings,
+        // where the first bit is the most significant bit of the byte.
+        preprocessedMessage.append(0x80)
+
+        // Pre-processing: padding with zeros
+        // append "0" bit until message length in bits ≡ 448 (mod 512)
+        let desiredMessageLengthModulo = messageLengthBits - 8
+        var messageLength = preprocessedMessage.count
+        var paddingCounter = 0
+        while messageLength % messageLengthBits != desiredMessageLengthModulo {
+            paddingCounter += 1
+            messageLength += 1
+        }
+        preprocessedMessage += [UInt8](repeating: 0, count: paddingCounter)
+        // append original length in bits mod (2 pow 64) to message
+        preprocessedMessage.reserveCapacity(preprocessedMessage.count + 4)
+        let lengthInBits = message.count * 8
+        let lengthBytes = Representations.toUInt8Array(value: lengthInBits, length: 64 / 8)
+        preprocessedMessage += lengthBytes
+        return preprocessedMessage
+    }
+
+    // MARK: 64 bit version
+
+    static func hash64Bit(message: [UInt8]) -> [UInt8] {
+        // Initialize variables:
+        var a0 = h[0] // A
+        var b0 = h[1] // B
+        var c0 = h[2] // C
+        var d0 = h[3] // D
+        var e0 = h[4] // E
+        var f0 = h[5] // F
+        var g0 = h[6] // G
+        var h0 = h[7] // H
+
+        // Pre-processing
+        let preprocessedMessage = preprocessMessage(message: message,
+                                                    messageLengthBits: blockSize)
+
+        // Process the message in successive 512-bit chunks:
+        let chunkSizeBytes = 1024 / 8
+        for chunk in preprocessedMessage.splitToChuncks(chunkSizeBytes) {
+            // Break chunk into sixteen 32-bit big-endian words w[i], 0 ≤ i ≤ 15
+            // Extend the sixteen 32-bit words into eighty 32-bit words:
+            var M = [UInt64](repeating: 0, count: k.count)
+
+            for x in 0 ..< M.count {
+                switch x {
+                case 0 ... 15:
+                    let start = chunk.startIndex + (x * MemoryLayout.size(ofValue: M[x]))
+                    let end = start + MemoryLayout.size(ofValue: M[x])
+                    let le = Representations.mergeToUInt64Array(slice: chunk[start ..< end])[0]
+                    M[x] = le.bigEndian
+                default:
+                    let s0 = M[x - 15].rotateRight(1) ^ M[x - 15].rotateRight(8) ^ M[x - 15] >> 7
+                    let s1 = M[x - 2].rotateRight(19) ^ M[x - 2].rotateRight(61) ^ M[x - 2] >> 6
+                    M[x] = M[x - 16] &+ s0 &+ M[x - 7] &+ s1
+                }
+            }
+
+            // Initialize hash value for this chunk:
+            var A = a0
+            var B = b0
+            var C = c0
+            var D = d0
+            var E = e0
+            var F = f0
+            var G = g0
+            var H = h0
+
+            // Main loop:
+            for i in 0 ..< k.count {
+                let S1 = E.rotateRight(14) ^ E.rotateRight(18) ^ E.rotateRight(41)
+                let ch = (E & F) ^ (~E & G)
+                let temp1 = H &+ S1 &+ ch &+ UInt64(k[i]) &+ M[i]
+                let S0 = A.rotateRight(28) ^ A.rotateRight(34) ^ A.rotateRight(39)
+                let maj = (A & B) ^ (A & C) ^ (B & C)
+                let temp2 = S0 &+ maj
+
+                H = G
+                G = F
+                F = E
+                E = D &+ temp1
+                D = C
+                C = B
+                B = A
+                A = temp1 &+ temp2
+            }
+
+            // Add this chunk's hash to result so far:
+            a0 = (a0 &+ A)
+            b0 = (b0 &+ B)
+            c0 = (c0 &+ C)
+            d0 = (d0 &+ D)
+            e0 = (e0 &+ E)
+            f0 = (f0 &+ F)
+            g0 = (g0 &+ G)
+            h0 = (h0 &+ H)
+        }
+
+        // Produce the final hash value (big-endian) as a 160 bit number:
+        var result = [UInt8]()
+        result.reserveCapacity(160 / 8)
+
+        for item in truncateResult(h: [a0, b0, c0, d0, e0, f0, g0, h0]) {
+            result += Representations.toUInt8Array(value: item.bigEndian.reverseBytes())
+        }
+
+        return result
+    }
+
+    // swiftlint:enable function_body_length
+
+    static func hash64Bit(message: String) -> String {
+        Representations.toHexadecimalString(
+            bytes: hash64Bit(message: Array(message.utf8))
+        )
+    }
+}
+
+public extension Array {
+    func splitToChuncks(_ chunkSize: Int) -> AnyIterator<ArraySlice<Element>> {
+        var offset = 0
+        return AnyIterator {
+            let end = Swift.min(chunkSize, self.count - offset)
+            let result = self[offset ..< offset + end]
+            offset += result.count
+            return !result.isEmpty ? result : nil
+        }
+    }
+}
+
+extension UInt64 {
+    func rotateLeft(_ times: UInt64) -> UInt64 {
+        (self << times) | (self >> (64 - times))
+    }
+
+    func rotateRight(_ times: UInt64) -> UInt64 {
+        (self >> times) | (self << (64 - times))
+    }
+
+    func reverseBytes() -> UInt64 {
+        let tmp1 = ((self & 0x0000_0000_0000_00FF) << 56) |
+            ((self & 0x0000_0000_0000_FF00) << 40) |
+            ((self & 0x0000_0000_00FF_0000) << 24) |
+            ((self & 0x0000_0000_FF00_0000) << 8)
+
+        let tmp2 = ((self & 0x0000_00FF_0000_0000) >> 8) |
+            ((self & 0x0000_FF00_0000_0000) >> 24) |
+            ((self & 0x00FF_0000_0000_0000) >> 40) |
+            ((self & 0xFF00_0000_0000_0000) >> 56)
+
+        return tmp1 | tmp2
+    }
+}
+
+class Representations {
+    // Array of bytes with optional padding (little-endian)
+    static func toUInt8Array<T>(value: T, length: Int? = nil) -> [UInt8] {
+        let totalBytes = length ?? MemoryLayout<T>.size
+        var copyOfValue = value
+
+        return withUnsafePointer(to: &copyOfValue) {
+            Array(UnsafeBufferPointer(start: UnsafePointer<UInt8>(OpaquePointer($0)), count: totalBytes)).reversed()
+        }
+    }
+
+    // Merge Array of UInt8 to array of UInt32
+    static func mergeToUInt32Array(slice: ArraySlice<UInt8>) -> [UInt32] {
+        var result = [UInt32]()
+        result.reserveCapacity(16)
+
+        for idx in stride(from: slice.startIndex, to: slice.endIndex, by: MemoryLayout<UInt32>.size) {
+            let val1 = UInt32(slice[idx.advanced(by: 3)]) << 24
+            let val2 = UInt32(slice[idx.advanced(by: 2)]) << 16
+            let val3 = UInt32(slice[idx.advanced(by: 1)]) << 8
+            let val4 = UInt32(slice[idx])
+            let val: UInt32 = val1 | val2 | val3 | val4
+            result.append(val)
+        }
+
+        return result
+    }
+
+    // Merge Array of UInt8 to array of UInt64
+    static func mergeToUInt64Array(slice: ArraySlice<UInt8>) -> [UInt64] {
+        var result = [UInt64]()
+        result.reserveCapacity(32)
+
+        for idx in stride(from: slice.startIndex, to: slice.endIndex, by: MemoryLayout<UInt64>.size) {
+            let val1 = UInt64(slice[idx.advanced(by: 7)]) << 56
+            let val2 = UInt64(slice[idx.advanced(by: 6)]) << 48
+            let val3 = UInt64(slice[idx.advanced(by: 5)]) << 40
+            let val4 = UInt64(slice[idx.advanced(by: 4)]) << 32
+            let val5 = UInt64(slice[idx.advanced(by: 3)]) << 24
+            let val6 = UInt64(slice[idx.advanced(by: 2)]) << 16
+            let val7 = UInt64(slice[idx.advanced(by: 1)]) << 8
+            let val8 = UInt64(slice[idx])
+            let val: UInt64 = val1 | val2 | val3 | val4 | val5 | val6 | val7 | val8
+            result.append(val)
+        }
+
+        return result
+    }
+
+    // Return hexadecimal string representation of Array<UInt8>
+    static func toHexadecimalString(bytes: [UInt8]) -> String {
+        var hexString = String()
+        for byte in bytes {
+            hexString += String(format: "%02x", byte)
+        }
+
+        return hexString
+    }
+}

--- a/liquid-auth-ios/liquid-auth-ios/Utility.swift
+++ b/liquid-auth-ios/liquid-auth-ios/Utility.swift
@@ -68,4 +68,28 @@ struct Utility {
         // Decode the Base64 string
         return Data(base64Encoded: base64)
     }
+
+    /// Decodes a Base64Url string into a JSON representation of bytes.
+    public static func decodeBase64UrlToJSON(_ base64Url: String) -> String? {
+        // Decode the Base64Url string into Data
+        guard let decodedData = decodeBase64Url(base64Url) else {
+            return nil
+        }
+        
+        // Convert Data to [UInt8]
+        let decodedBytes = [UInt8](decodedData)
+        
+        // Create a dictionary where each byte is represented as a key-value pair
+        let byteDictionary = decodedBytes.enumerated().reduce(into: [String: UInt8]()) { dict, pair in
+            dict["\(pair.offset)"] = pair.element
+        }
+        
+        // Convert the dictionary to a JSON string
+        if let jsonData = try? JSONSerialization.data(withJSONObject: byteDictionary, options: [.prettyPrinted]),
+        let jsonString = String(data: jsonData, encoding: .utf8) {
+            return jsonString
+        }
+        
+        return nil
+    }
 }

--- a/liquid-auth-ios/liquid-auth-ios/Utility.swift
+++ b/liquid-auth-ios/liquid-auth-ios/Utility.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Base32
 
 struct Utility {
     /// Extracts the origin and request ID from a Liquid Auth URI.
@@ -24,5 +25,29 @@ struct Utility {
         let systemVersion = UIDevice.current.systemVersion
 
         return "\(appName)/\(appVersion) (\(deviceModel); \(systemName) \(systemVersion))"
+    }
+    public static func sha512_256(data: Data) -> Data {
+        Data(SHA512_256().hash([UInt8](data)))
+    }
+    
+    public static func encodeAddress(bytes: Data) throws -> String {
+        let lenBytes = 32
+        let checksumLenBytes = 4
+        let expectedStrEncodedLen = 58
+
+        // compute sha512/256 checksum
+        let hash = sha512_256(data: bytes)
+        let hashedAddr = hash[..<lenBytes] // Take the first 32 bytes
+
+        // take the last 4 bytes of the hashed address, and append to original bytes
+        let checksum = hashedAddr[(hashedAddr.count - checksumLenBytes)...]
+        let checksumAddr = bytes + checksum
+
+        // encodeToMsgPack addr+checksum as base32 and return. Strip padding.
+        let res = Base32.base32Encode(checksumAddr).trimmingCharacters(in: ["="])
+        if res.count != expectedStrEncodedLen {
+         throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "unexpected address length \(res.count)"])
+        }
+        return res
     }
 }

--- a/liquid-auth-ios/liquid-auth-ios/Utility.swift
+++ b/liquid-auth-ios/liquid-auth-ios/Utility.swift
@@ -137,7 +137,7 @@ struct Utility {
         let cborPublicKey = encodePKToEC2COSEKey(publicKey)
 
         let credentialIdLengthData = UInt16(credentialId.count).toDataBigEndian()
-        return aaguid.toData() + credentialIdLengthData + credentialId + publicKey
+        return aaguid.toData() + credentialIdLengthData + credentialId + cborPublicKey
     }
 
     static func hashSHA256(_ input: Data) -> Data {

--- a/liquid-auth-ios/liquid-auth-ios/Utility.swift
+++ b/liquid-auth-ios/liquid-auth-ios/Utility.swift
@@ -1,0 +1,28 @@
+import Foundation
+import UIKit
+
+struct Utility {
+    /// Extracts the origin and request ID from a Liquid Auth URI.
+    static func extractOriginAndRequestId(from uri: String) -> (origin: String, requestId: String)? {
+        guard let url = URL(string: uri),
+              url.scheme == "liquid",
+              let host = url.host,
+              let queryItems = URLComponents(string: uri)?.queryItems,
+              let requestId = queryItems.first(where: { $0.name == "requestId" })?.value else {
+            print("Invalid Liquid Auth URI format.")
+            return nil
+        }
+        return (origin: host, requestId: requestId)
+    }
+
+    /// Constructs a user agent string based on the app and device information.
+    static func getUserAgent() -> String {
+        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "UnknownApp"
+        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "UnknownVersion"
+        let deviceModel = UIDevice.current.model
+        let systemName = UIDevice.current.systemName
+        let systemVersion = UIDevice.current.systemVersion
+
+        return "\(appName)/\(appVersion) (\(deviceModel); \(systemName) \(systemVersion))"
+    }
+}

--- a/liquid-auth-ios/liquid-auth-ios/Utility.swift
+++ b/liquid-auth-ios/liquid-auth-ios/Utility.swift
@@ -30,6 +30,7 @@ struct Utility {
         Data(SHA512_256().hash([UInt8](data)))
     }
     
+    /// Encode an Ed25519 public key into an Algorand Base32 address with the checksum.
     public static func encodeAddress(bytes: Data) throws -> String {
         let lenBytes = 32
         let checksumLenBytes = 4
@@ -49,5 +50,22 @@ struct Utility {
          throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "unexpected address length \(res.count)"])
         }
         return res
+    }
+
+    /// Decodes a Base64Url string into bytes.
+    public static func decodeBase64Url(_ base64Url: String) -> Data? {
+        // Replace Base64Url characters with Base64 equivalents
+        var base64 = base64Url
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        
+        // Add padding if necessary
+        let paddingLength = 4 - (base64.count % 4)
+        if paddingLength < 4 {
+            base64.append(String(repeating: "=", count: paddingLength))
+        }
+        
+        // Decode the Base64 string
+        return Data(base64Encoded: base64)
     }
 }

--- a/liquid-auth-ios/liquid-auth-ios/auth.request.json
+++ b/liquid-auth-ios/liquid-auth-ios/auth.request.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://arc52/schemas/auth.request.json",
+  "title": "Payment Transaction",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "0": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "1": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "2": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "3": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "4": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "5": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "6": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "7": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "8": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "9": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "10": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "11": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "12": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "13": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "14": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "15": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "16": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "17": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "18": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "19": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "20": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "21": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "22": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "23": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "24": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "25": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "26": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "27": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "28": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "29": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "30": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "31": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    }
+  },
+  "required": [
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+    "11",
+    "12",
+    "13",
+    "14",
+    "15",
+    "16",
+    "17",
+    "18",
+    "19",
+    "20",
+    "21",
+    "22",
+    "23",
+    "24",
+    "25",
+    "26",
+    "27",
+    "28",
+    "29",
+    "30",
+    "31"
+  ]
+}

--- a/liquid-auth-ios/liquid-auth-ios/liquid_auth_iosApp.swift
+++ b/liquid-auth-ios/liquid-auth-ios/liquid_auth_iosApp.swift
@@ -6,12 +6,30 @@
 //
 
 import SwiftUI
+import UserNotifications
 
 @main
 struct liquid_auth_iosApp: App {
+    init() {
+        requestNotificationPermissions()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+        }
+    }
+
+    private func requestNotificationPermissions() {
+        let notificationCenter = UNUserNotificationCenter.current()
+        notificationCenter.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if let error = error {
+                print("Failed to request notification permissions: \(error)")
+            } else if granted {
+                print("Notification permissions granted.")
+            } else {
+                print("Notification permissions denied.")
+            }
         }
     }
 }

--- a/liquid-auth-ios/liquid-auth-iosTests/FIDOHandlerTests.swift
+++ b/liquid-auth-ios/liquid-auth-iosTests/FIDOHandlerTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import liquid_auth_ios
+
+final class FIDOHandlerTests: XCTestCase {
+    func testDecodeFIDOURI() {
+        // Example FIDO URI (base10-encoded string)
+        let fidoURI = "FIDO:/674869333506131586293076724977443367731019628156292384354259529213161969518231792172611583034218375041007008870551213670082509686365434729312973136331522109321447142404"
+
+        // Decode the FIDO URI
+        guard let fidoRequest = FIDOHandler.decodeFIDOURI(fidoURI) else {
+            XCTFail("Failed to decode FIDO URI.")
+            return
+        }
+
+        // Assert required fields
+        XCTAssertEqual(fidoRequest.publicKey, [3, 208, 203, 139, 207, 78, 251, 171, 28, 112, 129, 103, 121, 23, 114, 214, 106, 118, 131, 132, 215, 9, 50, 66, 93, 79, 106, 100, 41, 30, 178, 37, 157], "Public key does not match.")
+        XCTAssertEqual(fidoRequest.qrSecret, [139, 59, 251, 214, 197, 13, 52, 93, 241, 58, 54, 187, 91, 163, 16, 199], "QR secret does not match.")
+        XCTAssertEqual(fidoRequest.tunnelServerCount, 2, "Tunnel server count does not match.")
+
+        // Assert optional fields
+        XCTAssertEqual(fidoRequest.currentTime, 1744715214, "Current time does not match.")
+        XCTAssertEqual(fidoRequest.stateAssisted, false, "State-assisted transactions flag does not match.")
+        XCTAssertEqual(fidoRequest.hint, "mc", "Hint does not match.")
+
+        // Assert flow type
+        XCTAssertEqual(fidoRequest.flowType, "MakeCredential", "Flow type does not match.")
+    }
+}


### PR DESCRIPTION
This level of code shows how we can use xHD-Wallet-API-Swift (using a temporary branch for now where validateData and rawSign are exposed) and deterministicP256-swift to generate and register a credential. It stops short of the signal service.